### PR TITLE
remove spacing above frame heading

### DIFF
--- a/source/beamerthememetrocity.sty
+++ b/source/beamerthememetrocity.sty
@@ -105,8 +105,8 @@
 %
 % ------------------------------------------------------------------------------------
 
-% add some spacing to the frame title
-\addtobeamertemplate{frametitle}{\vspace*{0.7em}}{\vspace*{1.0em}}
+% remove some spacing from the frame title
+\addtobeamertemplate{frametitle}{\vspace*{-2.5em}}{\vspace*{1.0em}}
 
 % add the universites logo to the right top of the frame
 \setbeamertemplate{headline}{


### PR DESCRIPTION
Since I moved the Logo from the background into the titleframe in https://github.com/pinnecke/metrocity/pull/1/ the heading on regular frames "slipped" to far down, which I unfortunately noticed too late. This PR fixes this. It has been tested with the the three aspect ratios mentioned in https://github.com/pinnecke/metrocity/pull/1/

before: 
![Screenshot from 2020-08-09 17-33-38](https://user-images.githubusercontent.com/12223583/89736276-7e619600-da68-11ea-9ce1-81767b1c4e07.png)

after:
![Screenshot from 2020-08-09 17-39-35](https://user-images.githubusercontent.com/12223583/89736280-8ae5ee80-da68-11ea-8d98-34f8f93262f0.png)

